### PR TITLE
så att recept bilder inte hamnar framför navbaren

### DIFF
--- a/src/assets/components/navBar/NavBar.css
+++ b/src/assets/components/navBar/NavBar.css
@@ -17,6 +17,7 @@ button {
   width: 100%;
   height: auto;
   margin: 0px;
+  z-index: 1; /*Så att navbaren inte hamnar bakom bild på receptkort när man scrollar ner*/
 }
 
 .Logotype {


### PR DESCRIPTION
satt en stack order (z-index: 1) på navbaren så att den hamnar framför bild från receptkort istället för bakom