### PR TITLE
Vid (900px) att nutritions fälls ihop under bild

### DIFF
--- a/src/assets/components/recipe-info/Recipe.css
+++ b/src/assets/components/recipe-info/Recipe.css
@@ -13,7 +13,7 @@
     border: 1px dashed black;
 } */
 
-@media screen and (min-width: 730px){
+@media screen and (min-width: 900px){
 
     /* START: Bild & Tabell samma rad */
     .picture-pictureInfo-and-nutritionTable-container{
@@ -24,7 +24,7 @@
         width: 70%;
     }
     .recipe-section-nutritionTable{
-        width: 25%;
+        width: 30%;
     }
     /* SLUT: Bild & Tabell samma rad */
 }

--- a/src/assets/components/recipe-info/Recipe.jsx
+++ b/src/assets/components/recipe-info/Recipe.jsx
@@ -23,9 +23,17 @@ export default function Recipe() {
   // const [recipe, setRecipe] = useState(null);
   const [similars, setSimilars] = useState();
   const [isMobile, setMobile] = useState(window.innerWidth < 730);
+  const [isTablet, setTablet] = useState(window.innerWidth < 900); /* Nutrition table går under receptbild och info (gömd under fällbarknapp) */
   const [servings, setServings] = useState(recipe.servings);
 
-  // const [liknande, setLiknande] = useState(null);
+  const updateMediaToTablet = () => {
+    setTablet(window.innerWidth < 900);
+  };
+
+  useEffect(() => {
+    window.addEventListener("resize", updateMediaToTablet);
+    return () => window.removeEventListener("resize", updateMediaToTablet);
+  }, [isTablet]);
 
   //Denna del av Shakiba
   const updateMedia = () => {
@@ -76,7 +84,7 @@ export default function Recipe() {
             </div>
             <>
               {/* Kollar om mobile version */}
-              {isMobile ? (
+              {isTablet ? (
                 /*Om Mobilversion*/
                 <div className="showMorebtn">
                   {/* Sätt en knapp för att visa nutritions*/}


### PR DESCRIPTION
Nutrition-table går under bild istället för jämte vid (900px) .
Fälls ihop direkt före ingrediens och steps som fälls ihop vid (730px) då den känns mindre viktig för användaren vid mindre skärm